### PR TITLE
Preserve key order separately for deterministic output

### DIFF
--- a/topsort.go
+++ b/topsort.go
@@ -27,23 +27,27 @@ import (
 // Network Helpers {{{
 
 type Network struct {
-	Nodes map[string]*Node
+	nodes map[string]*Node
+	order []string
 }
 
 func NewNetwork() *Network {
-	return &Network{Nodes: map[string]*Node{}}
+	return &Network{
+		nodes: map[string]*Node{},
+		order: []string{},
+	}
 }
 
 func (tn *Network) Sort() ([]*Node, error) {
 	nodes := make([]*Node, 0)
-	for _, v := range tn.Nodes {
-		nodes = append(nodes, v)
+	for _, key := range tn.order {
+		nodes = append(nodes, tn.nodes[key])
 	}
 	return sortNodes(nodes)
 }
 
 func (tn *Network) Get(name string) *Node {
-	return tn.Nodes[name]
+	return tn.nodes[name]
 }
 
 func (tn *Network) AddNode(name string, value interface{}) *Node {
@@ -55,7 +59,10 @@ func (tn *Network) AddNode(name string, value interface{}) *Node {
 		Marked:        false,
 	}
 
-	tn.Nodes[name] = &node
+	if _, ok := tn.nodes[name]; !ok {
+		tn.order = append(tn.order, name)
+	}
+	tn.nodes[name] = &node
 	return &node
 }
 

--- a/topsort_test.go
+++ b/topsort_test.go
@@ -50,6 +50,16 @@ func assert(t *testing.T, expr bool) {
 	}
 }
 
+func newAlphaNetwork(start, end rune) *topsort.Network {
+	network := topsort.NewNetwork()
+
+	for c := start; c <= end; c++ {
+		network.AddNode(string(c), nil)
+	}
+
+	return network
+}
+
 // }}}
 
 func TestTopsortEasy(t *testing.T) {
@@ -70,21 +80,10 @@ func TestTopsortCycle(t *testing.T) {
 	network.AddEdge("bar", "foo")
 	_, err := network.Sort()
 	notok(t, err)
-
 }
 
 func TestTopsortLongCycle(t *testing.T) {
-	network := topsort.NewNetwork()
-
-	network.AddNode("A", nil)
-	network.AddNode("B", nil)
-	network.AddNode("C", nil)
-	network.AddNode("D", nil)
-	network.AddNode("E", nil)
-	network.AddNode("F", nil)
-	network.AddNode("G", nil)
-	network.AddNode("H", nil)
-	network.AddNode("I", nil)
+	network := newAlphaNetwork('A', 'I')
 
 	network.AddEdge("A", "B")
 	network.AddEdge("B", "C")
@@ -106,14 +105,7 @@ func TestTopsortLong(t *testing.T) {
 		 \    ^
 		  \-> F
 	*/
-	network := topsort.NewNetwork()
-
-	network.AddNode("A", nil)
-	network.AddNode("B", nil)
-	network.AddNode("C", nil)
-	network.AddNode("D", nil)
-	network.AddNode("E", nil)
-	network.AddNode("F", nil)
+	network := newAlphaNetwork('A', 'F')
 
 	network.AddEdge("A", "B")
 	network.AddEdge("A", "F")
@@ -130,6 +122,33 @@ func TestTopsortLong(t *testing.T) {
 	assert(t, series[1].Name == "F")
 	assert(t, series[2].Name == "B")
 	assert(t, series[3].Name == "C")
+}
+
+func TestDeterminism(t *testing.T) {
+	network := newAlphaNetwork('A', 'D')
+
+	series, err := network.Sort()
+	isok(t, err)
+	assert(t, len(series) == 4)
+
+	assert(t, series[0].Name == "A")
+	assert(t, series[1].Name == "B")
+	assert(t, series[2].Name == "C")
+	assert(t, series[3].Name == "D")
+
+	network = newAlphaNetwork('A', 'E')
+
+	network.AddEdge("D", "A")
+
+	series, err = network.Sort()
+	isok(t, err)
+	assert(t, len(series) == 5)
+
+	assert(t, series[0].Name == "B")
+	assert(t, series[1].Name == "C")
+	assert(t, series[2].Name == "D")
+	assert(t, series[3].Name == "E")
+	assert(t, series[4].Name == "A")
 }
 
 // vim: foldmethod=marker


### PR DESCRIPTION
Fixes #3

I'm not 100% happy with the test, and I'm happy to unroll out that test helper too if you don't like it, but I think it's a good start, and at least does ensure we have consistent deterministic output.

As always, would love some direction if this isn't what you'd like to see. :smile:

Just as a note, I made the `Nodes` key private because it needs to stay in sync with the new `order` key, so I wanted to make sure library users only use the appropriately defined interfaces for adding new nodes.
