### PR TITLE
Reset "Marked" status after sorting (to allow for re-sorting, especially after adding new edges or nodes)

### DIFF
--- a/topsort.go
+++ b/topsort.go
@@ -148,6 +148,10 @@ func sortNodes(nodes []*Node) (ret []*Node, err error) {
 		}
 		ret = append(ret, generation...)
 	}
+	/* Reset Marked status of nodes now that we're done */
+	for _, node := range nodes {
+		node.Marked = false
+	}
 	return
 }
 

--- a/topsort_test.go
+++ b/topsort_test.go
@@ -151,4 +151,38 @@ func TestDeterminism(t *testing.T) {
 	assert(t, series[4].Name == "A")
 }
 
+func TestReSort(t *testing.T) {
+	network := newAlphaNetwork('A', 'C')
+
+	series, err := network.Sort()
+	isok(t, err)
+	assert(t, len(series) == 3)
+
+	assert(t, series[0].Name == "A")
+	assert(t, series[1].Name == "B")
+	assert(t, series[2].Name == "C")
+
+	network.AddEdge("C", "A")
+
+	series, err = network.Sort()
+	isok(t, err)
+	assert(t, len(series) == 3)
+
+	assert(t, series[0].Name == "B")
+	assert(t, series[1].Name == "C")
+	assert(t, series[2].Name == "A")
+
+	network.AddNode("D", nil)
+	network.AddEdge("D", "B")
+
+	series, err = network.Sort()
+	isok(t, err)
+	assert(t, len(series) == 4)
+
+	assert(t, series[0].Name == "C")
+	assert(t, series[1].Name == "D")
+	assert(t, series[2].Name == "A")
+	assert(t, series[3].Name == "B")
+}
+
 // vim: foldmethod=marker


### PR DESCRIPTION
This one might be more of a documentation issue, but it seemed appropriate that given that the object is still mutable after a call to `Sort()` that it ought to be able to be `Sort()`ed again. :smile:
